### PR TITLE
Mask token

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -145,6 +145,9 @@ def _fetch_project(uri, version=None):
     use_temp_dst_dir = _is_zip_uri(parsed_uri) or not _is_local_uri(parsed_uri)
     dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else parsed_uri
     if use_temp_dst_dir:
+        # token present in URI
+        if '@' in uri:
+            uri = uri.split('@')[1]
         _logger.info("=== Fetching project from %s into %s ===", uri, dst_dir)
     if _is_zip_uri(parsed_uri):
         if _is_file_uri(parsed_uri):

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -126,7 +126,10 @@ export class RunViewImpl extends Component {
     const entryPointName = Utils.getEntryPointName(tags);
     const backend = Utils.getBackend(tags);
     if (Utils.getSourceType(tags) === 'PROJECT') {
-      runCommand = 'mlflow run GITHUB_URI' // + shellEscape(sourceName);  TODO: split string
+      if (sourceName.includes('@')) {
+        sourceName = sourceName.split('@')[1]
+      }
+      runCommand = 'mlflow run ' + shellEscape(sourceName);
       if (sourceVersion && sourceVersion !== 'latest') {
         runCommand += ' -v ' + shellEscape(sourceVersion);
       }

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -126,7 +126,7 @@ export class RunViewImpl extends Component {
     const entryPointName = Utils.getEntryPointName(tags);
     const backend = Utils.getBackend(tags);
     if (Utils.getSourceType(tags) === 'PROJECT') {
-      runCommand = 'mlflow run ' + shellEscape(sourceName);
+      runCommand = 'mlflow run GITHUB_URI' // + shellEscape(sourceName);  TODO: split string
       if (sourceVersion && sourceVersion !== 'latest') {
         runCommand += ' -v ' + shellEscape(sourceVersion);
       }


### PR DESCRIPTION
## What changes are proposed in this pull request?

One workaround to run projects from private GitHub repos is to generate a personal access token and use it as part of the URI, i.e. like:

mlflow run https://username:token@github.com/private_repo/
This token is being exposed in both the INFO logs and MLflow UI. The proposal is to run a simple regex pattern to detect if the token is present in the URI and mask it like https://xxx@github.com/private_repo through the logs and UI

## How is this patch tested?

(Details)

## Does this PR change the documentation?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure the changed pages / sections render correctly by following the steps below.

1. Check the status of the `ci/circleci: build_doc` check. If it's successful, proceed to the
   next step, otherwise fix it.
2. Click `Details` on the right to open the job page of CircleCI.
3. Click the `Artifacts` tab.
4. Click `docs/build/html/index.html`.
5. Find the changed pages / sections and make sure they render correctly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
